### PR TITLE
Fix numpy dtypes

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -558,7 +558,7 @@ def line_count_sort(file_list, target_dir):
         unsorted[count][1] = total_lines - docstr_lines
         unsorted[count][0] = exmpl
     index = np.lexsort((unsorted[:, 0].astype(np.str),
-                        unsorted[:, 1].astype(np.float)))
+                        unsorted[:, 1].astype(float)))
     if not len(unsorted):
         return []
     return np.array(unsorted[index][:, 0]).tolist()

--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -88,15 +88,15 @@ class LibAVReader():
 
         self.inputfps = -1
         if ("-r" in inputdict):
-            self.inputfps = np.int(inputdict["-r"])
+            self.inputfps = int(inputdict["-r"])
         elif "avg_frame_rate" in viddict:
             # check for the slash
             frtxt = viddict["avg_frame_rate"]
             parts = frtxt.split('/') 
             if len(parts) > 1:
-                self.inputfps = np.float(parts[0])/np.float(parts[1])
+                self.inputfps = float(parts[0])/float(parts[1])
             else:
-                self.inputfps = np.float(frtxt)
+                self.inputfps = float(frtxt)
         else:
             # simply default to a common 25 fps and warn
             self.inputfps = 25
@@ -105,11 +105,11 @@ class LibAVReader():
         # if we don't have width or height at all, raise exception
         if ("-s" in inputdict):
             widthheight = inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = int(widthheight[0])
+            self.inputheight = int(widthheight[1])
         elif (("width" in viddict) and ("height" in viddict)):
-            self.inputwidth = np.int(viddict["width"])
-            self.inputheight = np.int(viddict["height"])
+            self.inputwidth = int(viddict["width"])
+            self.inputheight = int(viddict["height"])
         else:
             raise ValueError("No way to determine width or height from video. Need `-s` in `inputdict`. Consult documentation on I/O.")
 
@@ -126,19 +126,19 @@ class LibAVReader():
             if verbosity != 0:
                 warnings.warn("No input color space detected. Assuming yuvj444p.", UserWarning)
 
-        self.inputdepth = np.int(bpplut[self.pix_fmt][0])
-        self.bpp = np.int(bpplut[self.pix_fmt][1])
+        self.inputdepth = int(bpplut[self.pix_fmt][0])
+        self.bpp = int(bpplut[self.pix_fmt][1])
 
         if (self.extension == ".yuv"):
             israw = 1
 
         if ("-vframes" in outputdict):
-            self.inputframenum = np.int(outputdict["-vframes"])
+            self.inputframenum = int(outputdict["-vframes"])
         elif ("nb_frames" in viddict):
-            self.inputframenum = np.int(viddict["nb_frames"])
+            self.inputframenum = int(viddict["nb_frames"])
         elif israw == 1:
             # we can compute it based on the input size and color space
-            self.inputframenum = np.int(self.size / (self.inputwidth * self.inputheight * (self.bpp/8.0)))
+            self.inputframenum = int(self.size / (self.inputwidth * self.inputheight * (self.bpp/8.0)))
         else:
             self.inputframenum = -1
             if verbosity != 0:
@@ -157,14 +157,14 @@ class LibAVReader():
 
         if '-s' in outputdict:
             widthheight = outputdict["-s"].split('x')
-            self.outputwidth = np.int(widthheight[0])
-            self.outputheight = np.int(widthheight[1])
+            self.outputwidth = int(widthheight[0])
+            self.outputheight = int(widthheight[1])
         else:
             self.outputwidth = self.inputwidth
             self.outputheight = self.inputheight
 
-        self.outputdepth = np.int(bpplut[outputdict['-pix_fmt']][0])
-        self.outputbpp = np.int(bpplut[outputdict['-pix_fmt']][1])
+        self.outputdepth = int(bpplut[outputdict['-pix_fmt']][0])
+        self.outputbpp = int(bpplut[outputdict['-pix_fmt']][1])
 
 
         # Create input args
@@ -182,7 +182,7 @@ class LibAVReader():
             # open process with supplied arguments,
             # grabbing number of frames using ffprobe
             probecmd = [_AVCONV_PATH + "/avprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0", "-show_entries", "stream=nb_read_frames", "-of", "default=nokey=1:noprint_wrappers=1", self._filename]
-            self.inputframenum = np.int(check_output(probecmd).split('\n')[0])
+            self.inputframenum = int(check_output(probecmd).split('\n')[0])
 
         # Create process
 
@@ -350,8 +350,8 @@ class LibAVWriter():
 
         if ("-s" in self.inputdict):
             widthheight = self.inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = int(widthheight[0])
+            self.inputheight = int(widthheight[1])
         else: 
             self.inputdict["-s"] = str(N) + "x" + str(M)
             self.inputwidth = N

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -91,15 +91,15 @@ class FFmpegReader():
 
         self.inputfps = -1
         if ("-r" in inputdict):
-            self.inputfps = np.int(inputdict["-r"])
+            self.inputfps = int(inputdict["-r"])
         elif "@r_frame_rate" in viddict:
             # check for the slash
             frtxt = viddict["@r_frame_rate"]
             parts = frtxt.split('/')
             if len(parts) > 1:
-                self.inputfps = np.float(parts[0])/np.float(parts[1])
+                self.inputfps = float(parts[0])/float(parts[1])
             else:
-                self.inputfps = np.float(frtxt)
+                self.inputfps = float(frtxt)
         else:
             # simply default to a common 25 fps and warn
             self.inputfps = 25
@@ -108,11 +108,11 @@ class FFmpegReader():
         # if we don't have width or height at all, raise exception
         if ("-s" in inputdict):
             widthheight = inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = int(widthheight[0])
+            self.inputheight = int(widthheight[1])
         elif (("@width" in viddict) and ("@height" in viddict)):
-            self.inputwidth = np.int(viddict["@width"])
-            self.inputheight = np.int(viddict["@height"])
+            self.inputwidth = int(viddict["@width"])
+            self.inputheight = int(viddict["@height"])
         else:
             raise ValueError("No way to determine width or height from video. Need `-s` in `inputdict`. Consult documentation on I/O.")
 
@@ -129,19 +129,19 @@ class FFmpegReader():
             if verbosity != 0:
                 warnings.warn("No input color space detected. Assuming yuvj420p.", UserWarning)
 
-        self.inputdepth = np.int(bpplut[self.pix_fmt][0])
-        self.bpp = np.int(bpplut[self.pix_fmt][1])
+        self.inputdepth = int(bpplut[self.pix_fmt][0])
+        self.bpp = int(bpplut[self.pix_fmt][1])
 
         if (str.encode(self.extension) in [b".raw", b".yuv"]):
             israw = 1
 
         if ("-vframes" in outputdict):
-            self.inputframenum = np.int(outputdict["-vframes"])
+            self.inputframenum = int(outputdict["-vframes"])
         elif ("@nb_frames" in viddict):
-            self.inputframenum = np.int(viddict["@nb_frames"])
+            self.inputframenum = int(viddict["@nb_frames"])
         elif israw == 1:
             # we can compute it based on the input size and color space
-            self.inputframenum = np.int(self.size / (self.inputwidth * self.inputheight * (self.bpp/8.0)))
+            self.inputframenum = int(self.size / (self.inputwidth * self.inputheight * (self.bpp/8.0)))
         else:
             self.inputframenum = -1
             if verbosity != 0:
@@ -163,15 +163,15 @@ class FFmpegReader():
 
         if '-s' in outputdict:
             widthheight = outputdict["-s"].split('x')
-            self.outputwidth = np.int(widthheight[0])
-            self.outputheight = np.int(widthheight[1])
+            self.outputwidth = int(widthheight[0])
+            self.outputheight = int(widthheight[1])
         else:
             self.outputwidth = self.inputwidth
             self.outputheight = self.inputheight
 
 
-        self.outputdepth = np.int(bpplut[outputdict['-pix_fmt']][0])
-        self.outputbpp = np.int(bpplut[outputdict['-pix_fmt']][1])
+        self.outputdepth = int(bpplut[outputdict['-pix_fmt']][0])
+        self.outputbpp = int(bpplut[outputdict['-pix_fmt']][1])
 
         if '-vcodec' not in outputdict:
             outputdict['-vcodec'] = "rawvideo"
@@ -191,7 +191,7 @@ class FFmpegReader():
             # open process with supplied arguments,
             # grabbing number of frames using ffprobe
             probecmd = [_FFMPEG_PATH + "/ffprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0", "-show_entries", "stream=nb_read_frames", "-of", "default=nokey=1:noprint_wrappers=1", self._filename]
-            self.inputframenum = np.int(check_output(probecmd).split('\n')[0])
+            self.inputframenum = int(check_output(probecmd).split('\n')[0])
 
         # Create process
 
@@ -359,8 +359,8 @@ class FFmpegWriter():
 
         if ("-s" in self.inputdict):
             widthheight = self.inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = int(widthheight[0])
+            self.inputheight = int(widthheight[1])
         else: 
             self.inputdict["-s"] = str(N) + "x" + str(M)
             self.inputwidth = N

--- a/skvideo/measure/edge.py
+++ b/skvideo/measure/edge.py
@@ -38,10 +38,10 @@ def canny(frame):
 
     avg_window = gauss_window(4, 1.2) 
 
-    frame = frame.astype(np.float)
+    frame = frame.astype(float)
 
     # do a better threshood job lol
-    mu = np.zeros((M, N), dtype=np.float)
+    mu = np.zeros((M, N), dtype=float)
 
     scipy.ndimage.correlate1d(frame, avg_window, 0, mu, mode='constant')
     scipy.ndimage.correlate1d(mu, avg_window, 1, mu, mode='constant')

--- a/skvideo/measure/mse.py
+++ b/skvideo/measure/mse.py
@@ -38,10 +38,10 @@ def mse(referenceVideoData, distortedVideoData):
 
     assert C == 1, "mse called with videos containing %d channels. Please supply only the luminance channel" % (C,)
 
-    scores = np.zeros(T, dtype=np.float)
+    scores = np.zeros(T, dtype=float)
     for t in range(T):
-        referenceFrame = referenceVideoData[t].astype(np.float)
-        distortedFrame = distortedVideoData[t].astype(np.float)
+        referenceFrame = referenceVideoData[t].astype(float)
+        distortedFrame = distortedVideoData[t].astype(float)
 
         mse = np.mean((referenceFrame - distortedFrame)**2)
 

--- a/skvideo/measure/psnr.py
+++ b/skvideo/measure/psnr.py
@@ -35,7 +35,7 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    bitdepth = np.int(bitdepth)
+    bitdepth = int(bitdepth)
 
     assert(referenceVideoData.shape == distortedVideoData.shape)
 
@@ -43,13 +43,13 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
 
     assert C == 1, "psnr called with videos containing %d channels. Please supply only the luminance channel" % (C,)
 
-    maxvalue = np.int(2**bitdepth - 1)
+    maxvalue = int(2**bitdepth - 1)
     maxsq = maxvalue**2
 
-    scores = np.zeros(T, dtype=np.float)
+    scores = np.zeros(T, dtype=float)
     for t in range(T):
-        referenceFrame = referenceVideoData[t].astype(np.float)
-        distortedFrame = distortedVideoData[t].astype(np.float)
+        referenceFrame = referenceVideoData[t].astype(float)
+        distortedFrame = distortedVideoData[t].astype(float)
 
         mse = np.mean((referenceFrame - distortedFrame)**2)
         psnr = 10 * np.log10(maxsq / mse)

--- a/skvideo/measure/scene.py
+++ b/skvideo/measure/scene.py
@@ -21,7 +21,7 @@ def _percentage_distance(canny_in, canny_out, r):
     E_1 = scipy.ndimage.morphology.binary_dilation(canny_in, structure=diamond, iterations=r)
     E_2 = scipy.ndimage.morphology.binary_dilation(canny_out, structure=diamond, iterations=r)
 
-    return 1.0 - np.float(np.sum(E_1 & E_2))/np.float(np.sum(E_1))
+    return 1.0 - float(np.sum(E_1 & E_2))/float(np.sum(E_1))
 
 def _scenedet_edges(videodata, threshold):
     # the first frame is always a new scene
@@ -72,8 +72,8 @@ def _scenedet_intensity(videodata, parameter1):
         hist1, bins = np.histogram(luminancedata[t], bins=256, range=(0, 255))
         hist2, bins = np.histogram(luminancedata[t+1], bins=256, range=(0, 255))
 
-        hist1 = hist1.astype(np.float)
-        hist2 = hist2.astype(np.float)
+        hist1 = hist1.astype(float)
+        hist2 = hist2.astype(float)
 
         hist1 /= 256.0
         hist2 /= 256.0

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -70,21 +70,21 @@ def ssim(referenceVideoData, distortedVideoData, bitdepth=8):
     avg_window = gauss_window(5, 1.5)
     K_1 = 0.01
     K_2 = 0.03
-    L = np.int(2**bitdepth - 1)
+    L = int(2**bitdepth - 1)
 
     C1 = (K_1 * L)**2
     C2 = (K_2 * L)**2
 
-    mu1 = np.zeros((M, N), dtype=np.float)
-    mu2 = np.zeros((M, N), dtype=np.float)
-    var1 = np.zeros((M, N), dtype=np.float)
-    var2 = np.zeros((M, N), dtype=np.float)
-    var12 = np.zeros((M, N), dtype=np.float)
+    mu1 = np.zeros((M, N), dtype=float)
+    mu2 = np.zeros((M, N), dtype=float)
+    var1 = np.zeros((M, N), dtype=float)
+    var2 = np.zeros((M, N), dtype=float)
+    var12 = np.zeros((M, N), dtype=float)
 
-    scores = np.zeros(T, dtype=np.float)
+    scores = np.zeros(T, dtype=float)
     for t in range(T):
-        referenceFrame = referenceVideoData[t].astype(np.float)
-        distortedFrame = distortedVideoData[t].astype(np.float)
+        referenceFrame = referenceVideoData[t].astype(float)
+        distortedFrame = distortedVideoData[t].astype(float)
         scipy.ndimage.correlate1d(referenceFrame, avg_window, 0, mu1, mode=extend_mode)
         scipy.ndimage.correlate1d(mu1, avg_window, 1, mu1, mode=extend_mode)
         scipy.ndimage.correlate1d(distortedFrame, avg_window, 0, mu2, mode=extend_mode)

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -6,17 +6,17 @@ from ..utils import *
 
 
 def _costMAD(block1, block2):
-    block1 = block1.astype(np.float)
-    block2 = block2.astype(np.float)
+    block1 = block1.astype(float)
+    block2 = block2.astype(float)
     return np.mean(np.abs(block1 - block2))
 
 
 def _minCost(costs):
     h, w = costs.shape
     if costs[h/2, w/2] == 0:
-        return np.int((h-1)/2), np.int((w-1)/2), 0
+        return int((h-1)/2), int((w-1)/2), 0
     idx = np.unravel_index(np.argmin(costs), costs.shape)
-    return np.int(idx[0]), np.int(idx[1]), costs[idx]
+    return int(idx[0]), int(idx[1]), costs[idx]
 
 
 def _checkBounded(xval, yval, w, h, mbSize):
@@ -251,7 +251,7 @@ def _ARPS(imgP, imgI, mbSize, p):
             else:
                 u = vectors[i / mbSize, j / mbSize - 1, 0]
                 v = vectors[i / mbSize, j / mbSize - 1, 1]
-                stepSize = np.int(np.max((np.abs(u), np.abs(v))))
+                stepSize = int(np.max((np.abs(u), np.abs(v))))
 
                 if (((np.abs(u) == stepSize) and (np.abs(v) == 0)) or
                     ((np.abs(v) == stepSize) and (np.abs(u) == 0))):
@@ -366,7 +366,7 @@ def _SE3SS(imgP, imgI, mbSize, p):
     for i in range(0, h - mbSize + 1, mbSize):
         for j in range(0, w - mbSize + 1, mbSize):
 
-            stepSize = np.int(stepMax)
+            stepSize = int(stepMax)
             x = j
             y = i
 
@@ -504,12 +504,12 @@ def _N3SS(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
     vectors = np.zeros((h / mbSize, w / mbSize, 2))
-    costs = np.ones((3, 3), dtype=np.float)*65537
+    costs = np.ones((3, 3), dtype=float)*65537
 
     computations = 0
 
     L = np.floor(np.log2(p + 1))
-    stepMax = np.int(2**(L - 1))
+    stepMax = int(2**(L - 1))
 
     for i in range(0, h - mbSize + 1, mbSize):
         for j in range(0, w - mbSize + 1, mbSize):
@@ -648,12 +648,12 @@ def _3SS(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
     vectors = np.zeros((h / mbSize, w / mbSize, 2))
-    costs = np.ones((3, 3), dtype=np.float)*65537
+    costs = np.ones((3, 3), dtype=float)*65537
 
     computations = 0
 
     L = np.floor(np.log2(p + 1))
-    stepMax = np.int(2**(L - 1))
+    stepMax = int(2**(L - 1))
 
     for i in range(0, h - mbSize + 1, mbSize):
         for j in range(0, w - mbSize + 1, mbSize):
@@ -708,7 +708,7 @@ def _4SS(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
     vectors = np.zeros((h / mbSize, w / mbSize, 2))
-    costs = np.ones((3, 3), dtype=np.float)*65537
+    costs = np.ones((3, 3), dtype=float)*65537
 
     computations = 0
     for i in range(0, h - mbSize + 1, mbSize):
@@ -727,8 +727,8 @@ def _4SS(imgP, imgI, mbSize, p):
                     if not _checkBounded(refBlkHor, refBlkVer, w, h, mbSize):
                         continue
 
-                    costRow = np.int(m/2 + 1)
-                    costCol = np.int(n/2 + 1)
+                    costRow = int(m/2 + 1)
+                    costCol = int(n/2 + 1)
                     if ((costRow == 1) and (costCol == 1)):
                         continue
                     costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -818,8 +818,8 @@ def _4SS(imgP, imgI, mbSize, p):
 def _ES(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
-    vectors = np.zeros((h / mbSize, w / mbSize, 2), dtype=np.float)
-    costs = np.ones((2 * p + 1, 2 * p + 1), dtype=np.float)*65537
+    vectors = np.zeros((h / mbSize, w / mbSize, 2), dtype=float)
+    costs = np.ones((2 * p + 1, 2 * p + 1), dtype=float)*65537
 
     # we start off from the top left of the image
     # we will walk in steps of mbSize

--- a/skvideo/tests/test_libav.py
+++ b/skvideo/tests/test_libav.py
@@ -17,7 +17,7 @@ def test_LibAVReader_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if int(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     reader = skvideo.io.LibAVReader(skvideo.datasets.bigbuckbunny(), verbosity=0)
@@ -49,7 +49,7 @@ def test_LibAVWriter_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if int(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     # generate random data for 5 frames

--- a/skvideo/tests/test_motion.py
+++ b/skvideo/tests/test_motion.py
@@ -8,7 +8,7 @@ import skvideo.datasets
 
 # gaussian ball
 def gauss(cx, cy, sigma, sz):
-    data = np.zeros((sz, sz, 3), dtype=np.float)
+    data = np.zeros((sz, sz, 3), dtype=float)
     for y in range(-sigma*3, sigma*3+1, 1):
         for x in range(-sigma*3, sigma*3+1, 1):
             magnitude = np.exp(-0.5 * (x**2 + y**2)/(sigma**2))
@@ -32,7 +32,7 @@ def getmockdata():
 def test_ES():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "ES")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     assert_equal(xmean, 0.31944444444444442)
@@ -42,7 +42,7 @@ def test_ES():
 def test_4SS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "4SS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     print(xmean, ymean)
@@ -53,7 +53,7 @@ def test_4SS():
 def test_3SS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "3SS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     assert_equal(xmean, 0.17361111111111111)
@@ -63,7 +63,7 @@ def test_3SS():
 def test_N3SS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "N3SS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
 
@@ -74,7 +74,7 @@ def test_N3SS():
 def test_SE3SS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "SE3SS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     assert_equal(xmean, 0.0208333333333333332)
@@ -84,7 +84,7 @@ def test_SE3SS():
 def test_ARPS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "ARPS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     assert_equal(ymean, -0.0069444444444444441)
@@ -94,7 +94,7 @@ def test_ARPS():
 def test_DS():
     dat = getmockdata()
     mvec = skvideo.motion.blockMotion(dat, "DS")
-    mvec = mvec.astype(np.float)
+    mvec = mvec.astype(float)
     xmean = np.mean(mvec[:, :, :, 0])
     ymean = np.mean(mvec[:, :, :, 1])
     assert_equal(ymean, -0.0069444444444444441)

--- a/skvideo/tests/test_vread.py
+++ b/skvideo/tests/test_vread.py
@@ -131,7 +131,7 @@ def test_vread_raw1_ffmpeg():
 def test_vread_raw1_libav_aboveversion9():
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if int(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
     _rawhelper1("libav")
 
@@ -144,7 +144,7 @@ def test_vread_raw2_libav_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if int(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     _rawhelper2("libav")

--- a/skvideo/tests/test_vreader.py
+++ b/skvideo/tests/test_vreader.py
@@ -43,7 +43,7 @@ def test_vreader_ffmpeg():
 @unittest.skipIf(not skvideo._HAS_AVCONV, "LibAV required for this test.")
 def test_vreader_libav_version12():
     try:
-        if np.int(skvideo._LIBAV_MAJOR_VERSION) < 12:
+        if int(skvideo._LIBAV_MAJOR_VERSION) < 12:
             return 0
     except:
         return 0

--- a/skvideo/tests/test_vwrite.py
+++ b/skvideo/tests/test_vwrite.py
@@ -42,7 +42,7 @@ def test_vreader_libav():
     if not skvideo._HAS_AVCONV:
         return 0
     try:
-        if np.int(skvideo._LIBAV_MAJOR_VERSION) < 12:
+        if int(skvideo._LIBAV_MAJOR_VERSION) < 12:
             return 0
     except:
         return 0


### PR DESCRIPTION
I made an attempt to address https://github.com/scikit-video/scikit-video/issues/154,
but went down a rabbit hole trying to fix test issues with the https://github.com/brentonmallen1/scikit-video/blob/fix_numpy_dtypes/skvideo/motion/block.py file.  I tried to convert divisions to use the `//` method but I feel like that's not the best way to go about doing that. maybe someone with more context could provide a more appropriate fix.